### PR TITLE
📝 [ #30 ] sequential/.mcfunction の @within アノテーションを修正

### DIFF
--- a/data/slot/function/perform/normal/sequential/.mcfunction
+++ b/data/slot/function/perform/normal/sequential/.mcfunction
@@ -2,7 +2,7 @@
 #
 # 連続演出。ショーコの独立宣言みたいな。成功すると発展
 #
-# @within function slot:reel/result/result_normal
+# @within function slot:perform/normal/
 
 ## スコアバグケア
     execute unless entity @s[scores={SeqInGame=-2147483648..2147483647}] run tellraw @a [{"storage":global,"nbt":"Prefix.WARN"},{"text":"SeqInGameが範囲外です。自動で初期値に戻しました。", "color":"yellow"}]


### PR DESCRIPTION
## 変更内容

`data/slot/function/perform/normal/sequential/.mcfunction` の `@within` アノテーションを実際の呼び出し元に合わせて修正。

### 修正前
```
# @within function slot:reel/result/result_normal
```

### 修正後
```
# @within function slot:perform/normal/
```

## 背景

Issue #30 で報告された通り、`sequential/` は `slot:reel/result/result_normal` からではなく `slot:perform/normal/` から呼ばれている。

Closes #30