### PR TITLE
⚡ slot:tick/ の毎tickエンティティスキャンを6回→2回に削減

### DIFF
--- a/data/slot/function/tick/.mcfunction
+++ b/data/slot/function/tick/.mcfunction
@@ -5,31 +5,31 @@
 # @within main:tick
 
 ## アイテム判別＆ツール処理（プレイヤーごと）
-execute as @a at @s run \
-function slot:tick/tools
+    execute as @a at @s run \
+    function slot:tick/tools
 
 ## スロットタイマー
-execute as @e[scores={SlotTimer=0..}] at @s run \
-scoreboard players add @s SlotTimer 1
+    execute as @e[scores={SlotTimer=0..}] at @s run \
+    scoreboard players add @s SlotTimer 1
 
 ## レバーが下げられた！リールスタート
 # SlotState=1 レバーが下げられる状態 / SlotState=2 役が決まった状態。どちらも is_stanby へ
-execute as @e[type=armor_stand,tag=slot_machine] at @s \
-if score @s SlotState matches 1..2 run \
-function slot:is_stanby
+    execute as @e[type=armor_stand,tag=slot_machine] at @s \
+    if score @s SlotState matches 1..2 run \
+    function slot:is_stanby
 # レバーアニメーション
-execute as @e[type=item_display,tag=slot_lever_display] at @s \
-if score @s SlotTimer matches 0.. run \
-function slot:parts/lever/animation
+    execute as @e[type=item_display,tag=slot_lever_display] at @s \
+    if score @s SlotTimer matches 0.. run \
+    function slot:parts/lever/animation
 
 ## スロット本体の状態処理（回転・結果・払い出し・ポイント）を1パスに統合
-execute as @e[type=armor_stand,tag=slot_machine] at @s run \
-function slot:tick/machine
+    execute as @e[type=armor_stand,tag=slot_machine] at @s run \
+    function slot:tick/machine
 
 ## ポイントバー表示
-execute as @e[type=text_display,tag=plus_point_display,scores={InPointIn=0..}] run \
-function slot:point/plus
+    execute as @e[type=text_display,tag=plus_point_display,scores={InPointIn=0..}] run \
+    function slot:point/plus
 
 ## ステージ名表示
-execute as @e[type=text_display,tag=StageDisplay,scores={InStageDisplay=0..}] run \
-function slot:perform/normal/stage/display/set_empty
+    execute as @e[type=text_display,tag=StageDisplay,scores={InStageDisplay=0..}] run \
+    function slot:perform/normal/stage/display/set_empty

--- a/data/slot/function/tick/.mcfunction
+++ b/data/slot/function/tick/.mcfunction
@@ -5,47 +5,31 @@
 # @within main:tick
 
 ## アイテム判別＆ツール処理（プレイヤーごと）
-    execute as @a at @s run \
-    function slot:tick/tools
+execute as @a at @s run \
+function slot:tick/tools
 
 ## スロットタイマー
-    execute as @e[scores={SlotTimer=0..}] at @s run \
-    scoreboard players add @s SlotTimer 1
+execute as @e[scores={SlotTimer=0..}] at @s run \
+scoreboard players add @s SlotTimer 1
 
 ## レバーが下げられた！リールスタート
-# SlotState=0 はレバーが下げられる状態。1にするにはfunction pull.mcfunction
-    execute as @e[type=armor_stand,tag=slot_machine] at @s \
-    if score @s SlotState matches 1 run \
-    function slot:is_stanby
-    # SlotState=2 役が決まった状態
-    execute as @e[type=armor_stand,tag=slot_machine] at @s \
-    if score @s SlotState matches 2 run \
-    function slot:is_stanby
-    # レバーアニメーション
-        execute as @e[type=item_display,tag=slot_lever_display] at @s \
-        if score @s SlotTimer matches 0.. run \
-        function slot:parts/lever/animation
-## 回転！
-# SlotState=3 回転中
-    execute as @e[type=armor_stand,tag=slot_machine] at @s \
-    if score @s SlotState matches 3 run \
-    function slot:reel/tick
-## 結果を表示
-# ButtonStateを1>2>3でリールストップ
-    execute as @e[type=armor_stand,tag=slot_machine] at @s \
-    if score @s SlotState matches 3 \
-    if score @s ButtonState matches 3 run \
-    function slot:reel/result/result_normal
-## 払い出し
-    execute as @e[type=armor_stand,tag=slot_machine] at @s \
-    if score @s InPayout matches 1 run \
-    function slot:money/payout/tick
-## ポイント加算
-    execute as @e[type=armor_stand,tag=slot_machine] at @s \
-    if score @s InPointIn matches 1 run \
-    function slot:point/tick
-    execute as @e[type=text_display,tag=plus_point_display,scores={InPointIn=0..}] run \
-    function slot:point/plus
+# SlotState=1 レバーが下げられる状態 / SlotState=2 役が決まった状態。どちらも is_stanby へ
+execute as @e[type=armor_stand,tag=slot_machine] at @s \
+if score @s SlotState matches 1..2 run \
+function slot:is_stanby
+# レバーアニメーション
+execute as @e[type=item_display,tag=slot_lever_display] at @s \
+if score @s SlotTimer matches 0.. run \
+function slot:parts/lever/animation
+
+## スロット本体の状態処理（回転・結果・払い出し・ポイント）を1パスに統合
+execute as @e[type=armor_stand,tag=slot_machine] at @s run \
+function slot:tick/machine
+
+## ポイントバー表示
+execute as @e[type=text_display,tag=plus_point_display,scores={InPointIn=0..}] run \
+function slot:point/plus
+
 ## ステージ名表示
-    execute as @e[type=text_display,tag=StageDisplay,scores={InStageDisplay=0..}] run \
-    function slot:perform/normal/stage/display/set_empty
+execute as @e[type=text_display,tag=StageDisplay,scores={InStageDisplay=0..}] run \
+function slot:perform/normal/stage/display/set_empty

--- a/data/slot/function/tick/machine.mcfunction
+++ b/data/slot/function/tick/machine.mcfunction
@@ -9,19 +9,19 @@
 
 ## 回転！
 # SlotState=3 回転中
-execute if score @s SlotState matches 3 run \
-function slot:reel/tick
+    execute if score @s SlotState matches 3 run \
+    function slot:reel/tick
 
 ## 結果を表示
 # ButtonStateを1>2>3でリールストップ
-execute if score @s SlotState matches 3 \
-if score @s ButtonState matches 3 run \
-function slot:reel/result/result_normal
+    execute if score @s SlotState matches 3 \
+    if score @s ButtonState matches 3 run \
+    function slot:reel/result/result_normal
 
 ## 払い出し
-execute if score @s InPayout matches 1 run \
-function slot:money/payout/tick
+    execute if score @s InPayout matches 1 run \
+    function slot:money/payout/tick
 
 ## ポイント加算
-execute if score @s InPointIn matches 1 run \
-function slot:point/tick
+    execute if score @s InPointIn matches 1 run \
+    function slot:point/tick

--- a/data/slot/function/tick/machine.mcfunction
+++ b/data/slot/function/tick/machine.mcfunction
@@ -1,0 +1,27 @@
+#> slot:tick/machine
+#
+# slot_machine（armor_stand）ごとの毎tick状態処理。
+# 以前は slot:tick/ 内で同じ slot_machine セレクタを
+# 状態ごとに別々にスキャンしていたものを 1 パスに統合し、
+# 各処理をスコアで分岐する（エンティティスキャン回数を削減）。
+#
+# @within function slot:tick/
+
+## 回転！
+# SlotState=3 回転中
+execute if score @s SlotState matches 3 run \
+function slot:reel/tick
+
+## 結果を表示
+# ButtonStateを1>2>3でリールストップ
+execute if score @s SlotState matches 3 \
+if score @s ButtonState matches 3 run \
+function slot:reel/result/result_normal
+
+## 払い出し
+execute if score @s InPayout matches 1 run \
+function slot:money/payout/tick
+
+## ポイント加算
+execute if score @s InPointIn matches 1 run \
+function slot:point/tick


### PR DESCRIPTION
**概要**
slot:tick/ では回転中スロット本体（armor_stand, tag=slot_machine）を状態ごとに別々のセレクタで毎tickスキャンしており、同じ全エンティティスキャンが1tickに6回走っていました。設置台数が増えるほど無駄が大きくなります。本PRは挙動を変えずにスキャン回数を 6回→2回 に削減します。

**変更点**
1つ目は is_stanby を呼ぶ2スキャン（SlotState=1 と =2）を matches 1..2 の1スキャンに統合。2つ目は回転・結果判定・払い出し・ポイント加算の4スキャンを新規ディスパッチ関数 slot:tick/machine の1スキャンに統合し、各処理を関数内でスコア分岐させました。

**挙動が変わらない理由**
各処理はその台自身と近傍の自分の表示エンティティのみを操作し、台をまたぐ依存はありません。result_normal が使う一時グローバルスコア（BeforePoint / LinkedSlotID）は同じ関数内でリセットされるため、パス統合による値の漏れもありません。レバーアニメーションのスキャンは元の位置のまま維持しています。

**テスト**
ゲーム内で レバー→回転→停止→払い出し→ポイント加算 の一連の動作確認を推奨します。