### PR TITLE
feat(perform): 多タイミング演出ディスパッチ層を追加

### DIFF
--- a/data/main/function/load/once.mcfunction
+++ b/data/main/function/load/once.mcfunction
@@ -49,6 +49,9 @@
     scoreboard objectives add Stage dummy "ステージ"
     scoreboard objectives add InStageDisplay dummy "ステージ表示中"
     scoreboard objectives add SeqInGame dummy "連続演出ゲーム数"
+    scoreboard objectives add PerformScenario dummy "演出シナリオ"
+    scoreboard objectives add PerformTimer dummy "演出タイマー"
+    scoreboard objectives add PerformStep dummy "演出ステップ"
 
     # 未分類
     scoreboard objectives add Direction dummy "方向"

--- a/data/slot/function/parts/button/push/center/update.mcfunction
+++ b/data/slot/function/parts/button/push/center/update.mcfunction
@@ -24,4 +24,5 @@
     #data remove storage slot:temp pos.center
     #data remove storage slot:temp reel.center
 
-## 結果による処理
+## 結果による処理（停止ごとの演出ディスパッチ）
+    function slot:perform/dispatch/on_stop

--- a/data/slot/function/parts/button/push/left/update.mcfunction
+++ b/data/slot/function/parts/button/push/left/update.mcfunction
@@ -24,4 +24,5 @@
     #data remove storage slot:temp pos.left
     #data remove storage slot:temp reel.left
 
-## 結果による処理
+## 結果による処理（停止ごとの演出ディスパッチ）
+    function slot:perform/dispatch/on_stop

--- a/data/slot/function/parts/button/push/right/update.mcfunction
+++ b/data/slot/function/parts/button/push/right/update.mcfunction
@@ -25,4 +25,5 @@
     #data remove storage slot:temp pos.right
     #data remove storage slot:temp reel.right
 
-## 結果による処理
+## 結果による処理（停止ごとの演出ディスパッチ）
+    function slot:perform/dispatch/on_stop

--- a/data/slot/function/perform/dispatch/on_lever.mcfunction
+++ b/data/slot/function/perform/dispatch/on_lever.mcfunction
@@ -1,0 +1,17 @@
+#> slot:perform/dispatch/on_lever
+#
+# 【再生レイヤー】レバーオン時の演出ディスパッチ。
+# select_scenario が決めた PerformScenario を読んで再生するだけ。
+# 結果(ResultID)は決して変えない。
+#
+# @within function slot:reel/result/set_normal
+
+    execute if score @s PerformScenario matches 1 run tellraw @a[team=Debug] [{"text":"[演出] 弱予告","color":"gray"}]
+    execute if score @s PerformScenario matches 2 run tellraw @a[team=Debug] [{"text":"[演出] 中予告","color":"aqua"}]
+    execute if score @s PerformScenario matches 3 run tellraw @a[team=Debug] [{"text":"[演出] 強予告！","color":"gold"}]
+    execute if score @s PerformScenario matches 5 run tellraw @a[team=Debug] [{"text":"[演出] カットイン!?","color":"light_purple"}]
+
+## 回転中アニメを使うシナリオはタイマー始動
+    execute if score @s PerformScenario matches 2.. run scoreboard players set @s PerformTimer 1
+
+#[TODO] ここで item_display / text_display の custom_model_data 切替などの本演出を実装する

--- a/data/slot/function/perform/dispatch/on_stop.mcfunction
+++ b/data/slot/function/perform/dispatch/on_stop.mcfunction
@@ -1,0 +1,18 @@
+#> slot:perform/dispatch/on_stop
+#
+# 【再生レイヤー】リール停止ごとの演出ディスパッチ。
+# ButtonState = 第何停止か(1..3)。PerformScenario と組み合わせて分岐。
+# 結果は変えない。各ボタン update の末尾から呼ぶ。
+#
+# @within function slot:parts/button/push/left/update
+# @within function slot:parts/button/push/center/update
+# @within function slot:parts/button/push/right/update
+
+## 第1停止
+    execute if score @s ButtonState matches 1 if score @s PerformScenario matches 3.. run tellraw @a[team=Debug] [{"text":"[演出] 第1停止：テンパイ煽り","color":"yellow"}]
+
+## 第2停止
+    execute if score @s ButtonState matches 2 if score @s PerformScenario matches 3.. run tellraw @a[team=Debug] [{"text":"[演出] 第2停止：カットイン発生","color":"gold"}]
+    execute if score @s ButtonState matches 2 if score @s PerformScenario matches 5 run playsound minecraft:block.note_block.pling player @a ~ ~ ~ 1 1.5
+
+#[TODO] 停止位置(Result_L/C/R)に応じた滑り・フラッシュ等

--- a/data/slot/function/perform/dispatch/on_third_stop.mcfunction
+++ b/data/slot/function/perform/dispatch/on_third_stop.mcfunction
@@ -1,0 +1,14 @@
+#> slot:perform/dispatch/on_third_stop
+#
+# 【再生レイヤー】全リール停止後の演出ディスパッチ。
+# 成否演出を出す。結果は ResultID で確定済みなので、それに沿わせるだけ。
+#
+# @within function slot:tick/machine
+
+## 煽ったがハズレ（信頼度演出の「裏切り」）
+    execute if score @s ResultID matches 1 if score @s PerformScenario matches 3.. run tellraw @a[team=Debug] [{"text":"[演出] 煽ったが…ハズレ","color":"red"}]
+
+## 役成立
+    execute if score @s ResultID matches 2.. if score @s PerformScenario matches 1.. run tellraw @a[team=Debug] [{"text":"[演出] 揃った！","color":"green"}]
+
+#[TODO] 役成立時のフラッシュ/ファンファーレ、PerformScenario リセットは slot:reset で実施

--- a/data/slot/function/perform/dispatch/reset.mcfunction
+++ b/data/slot/function/perform/dispatch/reset.mcfunction
@@ -1,0 +1,9 @@
+#> slot:perform/dispatch/reset
+#
+# 演出状態のリセット。1ゲーム終了時(slot:reset)から呼ぶ。
+#
+# @within function slot:reset
+
+    scoreboard players reset @s PerformScenario
+    scoreboard players set @s PerformTimer 0
+    scoreboard players set @s PerformStep 0

--- a/data/slot/function/perform/dispatch/select_scenario.mcfunction
+++ b/data/slot/function/perform/dispatch/select_scenario.mcfunction
@@ -1,0 +1,40 @@
+#> slot:perform/dispatch/select_scenario
+#
+# 演出シナリオ抽選。ResultID で条件付けして PerformScenario を決める。
+# ここが「信頼度」の本体 ＝ P(シナリオ | 結果) のテーブル。
+# 結果(ResultID)は絶対に変えない。レバーオン時に一度だけ呼ぶ。
+#
+# PerformScenario:
+#   0 = なし(通常)  1 = 弱予告  2 = 中予告  3 = 強予告  5 = カットイン
+#
+# @within function slot:reel/result/set_normal
+
+## 乱数
+    execute store result score @s _ run random value 1..1000
+
+## ハズレ(カス=1)：弱め中心、まれに強でフェイク（信頼度<100%を作る）
+    execute if score @s ResultID matches 1 if score @s _ matches 1..850 run scoreboard players set @s PerformScenario 0
+    execute if score @s ResultID matches 1 if score @s _ matches 851..960 run scoreboard players set @s PerformScenario 1
+    execute if score @s ResultID matches 1 if score @s _ matches 961..995 run scoreboard players set @s PerformScenario 2
+    execute if score @s ResultID matches 1 if score @s _ matches 996..1000 run scoreboard players set @s PerformScenario 3
+
+## 小役(ベル/リプレイ=2..5)
+    execute if score @s ResultID matches 2..5 if score @s _ matches 1..500 run scoreboard players set @s PerformScenario 0
+    execute if score @s ResultID matches 2..5 if score @s _ matches 501..800 run scoreboard players set @s PerformScenario 1
+    execute if score @s ResultID matches 2..5 if score @s _ matches 801..950 run scoreboard players set @s PerformScenario 2
+    execute if score @s ResultID matches 2..5 if score @s _ matches 951..1000 run scoreboard players set @s PerformScenario 3
+
+## レア(ルーン=6..11)：強予告・カットイン中心
+    execute if score @s ResultID matches 6..11 if score @s _ matches 1..250 run scoreboard players set @s PerformScenario 2
+    execute if score @s ResultID matches 6..11 if score @s _ matches 251..700 run scoreboard players set @s PerformScenario 3
+    execute if score @s ResultID matches 6..11 if score @s _ matches 701..1000 run scoreboard players set @s PerformScenario 5
+
+## 最強(ニンゲンヤメマスカ=12)
+    execute if score @s ResultID matches 12 run scoreboard players set @s PerformScenario 5
+
+## 演出進行用カウンタ初期化
+    scoreboard players set @s PerformStep 0
+    scoreboard players set @s PerformTimer 0
+
+## RESET
+    scoreboard players reset @s _

--- a/data/slot/function/perform/dispatch/tick.mcfunction
+++ b/data/slot/function/perform/dispatch/tick.mcfunction
@@ -1,0 +1,18 @@
+#> slot:perform/dispatch/tick
+#
+# 【再生レイヤー】回転中(SlotState=3)の毎tick演出。
+# PerformTimer / PerformStep で「フレーム送り」だけを担当する。
+# 結果は変えない。
+#
+# @within function slot:tick/machine
+
+## タイマーが動いているシナリオだけ処理
+    execute unless score @s PerformTimer matches 1.. run return fail
+
+    scoreboard players add @s PerformTimer 1
+
+## 例：20tickごとにフラッシュ音（PerformScenario ごとに差し替える想定）
+    execute if score @s PerformTimer matches 20 run playsound minecraft:block.amethyst_block.chime player @a ~ ~ ~ 0.6 2
+    execute if score @s PerformTimer matches 20 run scoreboard players set @s PerformTimer 1
+
+#[TODO] PerformScenario 別のフレーム制御（カットイン進行、ランプ点滅など）

--- a/data/slot/function/reel/result/set_normal.mcfunction
+++ b/data/slot/function/reel/result/set_normal.mcfunction
@@ -39,6 +39,10 @@
 ## 演出
     function slot:perform/normal/
 
+## 演出シナリオ抽選＋レバーオン演出（多タイミング演出ディスパッチ）
+    function slot:perform/dispatch/select_scenario
+    function slot:perform/dispatch/on_lever
+
 ## RESET
     scoreboard players reset @s _
 

--- a/data/slot/function/reset.mcfunction
+++ b/data/slot/function/reset.mcfunction
@@ -18,3 +18,6 @@
     tag @s add ReelingCenter
     tag @s add ReelingRight
     tag @s remove LeverAnimated
+
+## 演出リセット
+    function slot:perform/dispatch/reset

--- a/data/slot/function/tick/machine.mcfunction
+++ b/data/slot/function/tick/machine.mcfunction
@@ -12,11 +12,20 @@
     execute if score @s SlotState matches 3 run \
     function slot:reel/tick
 
+## 回転中の演出（多タイミング演出ディスパッチ）
+    execute if score @s SlotState matches 3 run \
+    function slot:perform/dispatch/tick
+
 ## 結果を表示
 # ButtonStateを1>2>3でリールストップ
     execute if score @s SlotState matches 3 \
     if score @s ButtonState matches 3 run \
     function slot:reel/result/result_normal
+
+## 全停止後の演出（多タイミング演出ディスパッチ）
+    execute if score @s SlotState matches 3 \
+    if score @s ButtonState matches 3 run \
+    function slot:perform/dispatch/on_third_stop
 
 ## 払い出し
     execute if score @s InPayout matches 1 run \

--- a/docs/PerformDispatch.md
+++ b/docs/PerformDispatch.md
@@ -1,0 +1,53 @@
+# 演出ディスパッチ（多タイミング演出システム）
+
+実機スロットと同じく、**結果はレバーオン時に1回だけ確定**し、**演出はレバーオン／各リール停止／全停止後／回転中**の複数タイミングで「再生」する。これを実現するための二層構造を `slot:perform/dispatch/` に追加した。
+
+## 二層構造
+
+```
+レバーオン（SlotState 0→1）
+  ↓
+① 抽選レイヤー（reel/result/set_normal 内）
+   役抽選        → ResultID
+   演出シナリオ抽選 → PerformScenario   ※ ResultID で条件付け＝信頼度の本体
+  ↓ 状態保存（スコアボード）
+   ResultID ・ PerformScenario ・ PerformTimer ・ PerformStep
+  ↓
+② 演出レイヤー（イベント駆動・保存値を読んで再生するだけ・結果は変えない）
+   on_lever        … レバーオン演出
+   on_stop         … 停止ごと（ButtonState=第何停止）
+   on_third_stop   … 全停止後
+   tick            … 回転中アニメ（PerformTimer 駆動）
+```
+
+## PerformScenario
+
+| 値 | 意味 |
+|----|------|
+| 0 | なし（通常） |
+| 1 | 弱予告 |
+| 2 | 中予告 |
+| 3 | 強予告 |
+| 5 | カットイン |
+
+`select_scenario` の重みテーブル ＝ `P(シナリオ | 結果)`。ハズレ(ResultID=1)でもまれに強予告を出すことで「信頼度 < 100%」を作り、プレイヤーが祈る体験を生む。
+
+## ファイル
+
+| ファイル | 役割 | 呼び出し元 |
+|----------|------|------------|
+| `dispatch/select_scenario` | シナリオ抽選（ResultID条件付け） | `reel/result/set_normal` |
+| `dispatch/on_lever` | レバーオン演出 | `reel/result/set_normal` |
+| `dispatch/on_stop` | 停止ごと演出 | `parts/button/push/{left,center,right}/update` |
+| `dispatch/on_third_stop` | 全停止後演出 | `tick/machine` |
+| `dispatch/tick` | 回転中アニメ | `tick/machine` |
+| `dispatch/reset` | 演出状態リセット | `slot:reset` |
+
+## スコアボード
+
+`PerformScenario` / `PerformTimer` / `PerformStep`（`main:load/once` で定義）。
+
+## 注意 / 今後
+
+- 現状の演出本体は Debug チーム向け `tellraw` のスキャフォルド。`#[TODO]` 箇所に `item_display` / `text_display` の `custom_model_data` 切替など本実装を入れる。
+- 既存の `perform/normal/`（smorker / sequential / stage）はレバーオン時演出として残置。将来的に `on_lever` 配下へ寄せて一本化すると整理しやすい。


### PR DESCRIPTION
## 概要
結果はレバーオン時に1回だけ確定し、演出を「レバーオン／各リール停止／全停止後／回転中」の複数タイミングで再生できるようにする二層構造を追加します。実機スロットと同じ「結果は1回・演出は何度でも」を実現します。

## 二層構造
- **抽選レイヤー**（`reel/result/set_normal` 内）: 役抽選=`ResultID` と並べて、演出シナリオ抽選=`PerformScenario` を **ResultID で条件付け**して確定します（= 信頼度テーブル `P(シナリオ|結果)`）。
- **演出レイヤー**（保存値を読んで再生するだけ・結果は変えない）: `on_lever` / `on_stop`（第何停止）/ `on_third_stop` / `tick`（回転中アニメ）。

## 変更点
- 新規 `data/slot/function/perform/dispatch/`: `select_scenario` `on_lever` `on_stop` `on_third_stop` `tick` `reset`
- 配線（最小限）: `reel/result/set_normal`、`parts/button/push/{left,center,right}/update`、`tick/machine`、`slot:reset`
- スコアボード追加（`main:load/once`）: `PerformScenario` / `PerformTimer` / `PerformStep`
- ドキュメント: `docs/PerformDispatch.md`

## 注意 / 今後
- 演出本体は現状 Debug チーム向け `tellraw` のスキャフォルドです（`#[TODO]` に `item_display`/`text_display` の本実装を入れる）。通常プレイには影響しません。
- 既存の `perform/normal/`（smorker / sequential / stage）は残置。将来 `on_lever` 配下へ寄せて一本化する余地があります。