### PR TITLE
🐛 統計集計のタグ掃除タイプミス修正 (linkd_player → linked_player)

### DIFF
--- a/data/slot/function/reel/result/symbol/bell/.mcfunction
+++ b/data/slot/function/reel/result/symbol/bell/.mcfunction
@@ -15,7 +15,7 @@
 ## 統計に足す
     function api:slot/get_player
     execute as @a[tag=linked_player] run scoreboard players add @s Bel 1
-    tag @a remove linkd_player
+    tag @a remove linked_player
 
 ## RESET
     scoreboard players reset @s _

--- a/data/slot/function/reel/result/symbol/kas/.mcfunction
+++ b/data/slot/function/reel/result/symbol/kas/.mcfunction
@@ -17,7 +17,7 @@ tellraw @a[team=Debug] {"text":"はずれ",color:"gray"}
 ## 統計に足す
     function api:slot/get_player
     execute as @a[tag=linked_player] run scoreboard players add @s Kas 1
-    tag @a remove linkd_player
+    tag @a remove linked_player
 
 ## 結果ID カス = 1
     scoreboard players set @s ResultID 1

--- a/data/slot/function/reel/result/symbol/ningen/.mcfunction
+++ b/data/slot/function/reel/result/symbol/ningen/.mcfunction
@@ -7,7 +7,7 @@
 ## 統計に足す
     function api:slot/get_player
     execute as @a[tag=linked_player] run scoreboard players add @s Bar 1
-    tag @a remove linkd_player
+    tag @a remove linked_player
 
 ## 結果ID ニンゲンヤメマスカ = 12
     scoreboard players set @s ResultID 12

--- a/data/slot/function/reel/result/symbol/replay/.mcfunction
+++ b/data/slot/function/reel/result/symbol/replay/.mcfunction
@@ -13,7 +13,7 @@
 ## 統計に足す
     function api:slot/get_player
     execute as @a[tag=linked_player] run scoreboard players add @s Rep 1
-    tag @a remove linkd_player
+    tag @a remove linked_player
 
 ## 結果ID リプレイ = 3 １枚払い出し = 4 ２枚払い出し = 5
     execute if score @s _ matches 1..40 run scoreboard players set @s ResultID 3

--- a/data/slot/function/reel/result/symbol/rune/.mcfunction
+++ b/data/slot/function/reel/result/symbol/rune/.mcfunction
@@ -29,7 +29,7 @@
 ## 統計に足す
     function api:slot/get_player
     execute as @a[tag=linked_player] run scoreboard players add @s Run 1
-    tag @a remove linkd_player
+    tag @a remove linked_player
 
 ## 結果ID(6..11) シングルrep = 6 シングルpay2 = 7 ダブル = 8 チェリー = 9 V = 10 トリプル = 11
     execute if score @s _ matches 1..2366 run scoreboard players set @s ResultID 6


### PR DESCRIPTION
## 概要
`api:slot/get_player` が付与する一時タグ `linked_player` の掃除コマンドが `linkd_player`(e抜けのタイプミス)になっており、タグが除去されていませんでした。残留した `linked_player` タグが意図しないプレイヤーを選択し、統計・ポイントの誤加算を招く恐れがあります。

## 修正内容
統計集計5ファイルで `tag @a remove linkd_player` を `linked_player` に修正:
bell / kas / ningen / replay / rune

該当コミット: 0478be4

Closes #49